### PR TITLE
DEVMODE object returns portrait resolutions on some devices

### DIFF
--- a/shared/pracxsettings.cpp
+++ b/shared/pracxsettings.cpp
@@ -589,7 +589,13 @@ bool CSettings::Load()
 
 	m_ptScreenSize.x = ReadIniInt("ScreenWidth", m_ptDefaultScreenSize.x, m_ptDefaultScreenSize.x, 1024);
 	m_ptScreenSize.y = ReadIniInt("ScreenHeight", m_ptDefaultScreenSize.y, m_ptDefaultScreenSize.y, 768);
-
+	
+	if (m_ptDefaultScreenSize.y > m_ptDefaultScreenSize.x)
+	{
+		m_ptDefaultScreenSize.y = dm.dmPelsHeight;
+		m_ptDefaultScreenSize.x = dm.dmPelsWidth;
+	}
+	
 	log(dm.dmPelsWidth << "\t" << dm.dmPelsHeight << "\t" << m_ptDefaultScreenSize.x << "\t" << m_ptDefaultScreenSize.y << "\t" << m_ptScreenSize.x << "\t" << m_ptScreenSize.y);
 
 	m_ptNewScreenSize = m_ptScreenSize;

--- a/shared/pracxsettings.cpp
+++ b/shared/pracxsettings.cpp
@@ -587,15 +587,16 @@ bool CSettings::Load()
 	m_ptDefaultScreenSize.x = dm.dmPelsWidth;
 	m_ptDefaultScreenSize.y = dm.dmPelsHeight;
 
-	m_ptScreenSize.x = ReadIniInt("ScreenWidth", m_ptDefaultScreenSize.x, m_ptDefaultScreenSize.x, 1024);
-	m_ptScreenSize.y = ReadIniInt("ScreenHeight", m_ptDefaultScreenSize.y, m_ptDefaultScreenSize.y, 768);
-	
 	if (m_ptDefaultScreenSize.y > m_ptDefaultScreenSize.x)
 	{
+		log("Portrait resolution detected: assuming landscape");
 		m_ptDefaultScreenSize.y = dm.dmPelsHeight;
 		m_ptDefaultScreenSize.x = dm.dmPelsWidth;
 	}
-	
+
+	m_ptScreenSize.x = ReadIniInt("ScreenWidth", m_ptDefaultScreenSize.x, m_ptDefaultScreenSize.x, 1024);
+	m_ptScreenSize.y = ReadIniInt("ScreenHeight", m_ptDefaultScreenSize.y, m_ptDefaultScreenSize.y, 768);
+
 	log(dm.dmPelsWidth << "\t" << dm.dmPelsHeight << "\t" << m_ptDefaultScreenSize.x << "\t" << m_ptDefaultScreenSize.y << "\t" << m_ptScreenSize.x << "\t" << m_ptScreenSize.y);
 
 	m_ptNewScreenSize = m_ptScreenSize;


### PR DESCRIPTION
I had a strange problem on my ASUS Transformer Mini hybrid Tablet/PC.

When PRACX was enabled, the game was unplayable, cropping the screen strangely.

I realized it was trying to run the game with portrait resolutions. Even by manually setting correct resolutions in the INI, the problem persisted.

I realized it had to do with an oddity on my device : the screen default orientation is portrait. Of course I was only trying to play on landscape mode, but I figured somehow that PRACX was only aware of the portrait dimensions of my resolution.

The DEVMODE object does not return the current actual screen orientation.